### PR TITLE
Update failed_tests_reporter.rb to fix an uninitialized constant error

### DIFF
--- a/lib/minitest_rerun_failed/failed_tests_reporter.rb
+++ b/lib/minitest_rerun_failed/failed_tests_reporter.rb
@@ -68,7 +68,7 @@ module Minitest
         tmp_haystack << test.failure.location
         tmp_haystack << test.to_s
         # Add filtered backtrace unless it is an unexpected error, which do not have a useful trace
-        tmp_haystack << filter_backtrace(test.failure.backtrace).join unless test.failure.is_a?(MiniTest::UnexpectedError)
+        tmp_haystack << filter_backtrace(test.failure.backtrace).join unless test.failure.is_a?(Minitest::UnexpectedError)
 
         # Get failure location as best we can from haystack
         if @include_line_numbers


### PR DESCRIPTION
```
`find_failure_location': uninitialized constant Minitest::Reporters::FailedTestsReporter::MiniTest (NameError)
        tmp_haystack << filter_backtrace(test.failure.backtrace).join unless test.failure.is_a?(MiniTest::UnexpectedError)
```

Got this error after upgrading my Ruby and Ruby on Rails to the latest version. Fixed it with this commit.