### PR TITLE
Switch dependency to minitest-reporters-next

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ bundle add "minitest-rerun-failed" --group test
 bundle binstubs minitest-rerun-failed
 ```
 
+This gem depends on [`minitest-reporters-next`](https://rubygems.org/gems/minitest-reporters-next), a community-maintained fork of `minitest-reporters` with minitest 6 support and compatibility with prepend-based plugins like `minitest-around`.
+
 ## Usage
 
 Use it like any Minitest::Reporters like such:

--- a/minitest_rerun_failed.gemspec
+++ b/minitest_rerun_failed.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables << "rerun_failed_tests"
 
   # Uncomment to register a new dependency of your gem
-  spec.add_runtime_dependency "minitest", "~> 5.0", ">= 5.0.0"
-  spec.add_runtime_dependency "minitest-reporters", "~> 1.4", ">= 1.4.0"
+  spec.add_runtime_dependency "minitest", ">= 5.0", "< 7"
+  spec.add_runtime_dependency "minitest-reporters-next", ">= 2.0"
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
## Summary

`minitest-reporters` uses `alias_method` chaining on `Minitest::Test#run`, which causes `SystemStackError` (infinite recursion) when combined with any plugin that uses `Module#prepend` on the same method — including `minitest-around` v0.6.0. This has been an open issue for months ([kern/minitest-reporters#367](https://github.com/kern/minitest-reporters/issues/367)) with a fix PR languishing ([kern/minitest-reporters#357](https://github.com/kern/minitest-reporters/pull/357)).

[`minitest-reporters-next`](https://rubygems.org/gems/minitest-reporters-next) is a community-maintained fork ([denselay/minitest-reporters](https://github.com/denselay/minitest-reporters)) that:
- Replaces `alias_method` with `Module#prepend` (the fix from #357)
- Adds minitest 6 support ([kern/minitest-reporters#366](https://github.com/kern/minitest-reporters/pull/366))
- Is a drop-in replacement — same `require 'minitest/reporters'` path and API

## Changes

- **gemspec**: Replace `minitest-reporters` runtime dependency with `minitest-reporters-next >= 2.0`
- **gemspec**: Widen `minitest` dependency to `>= 5.0, < 7` for minitest 6 support
- **README**: Document the `minitest-reporters-next` dependency