### PR TITLE
Report failures from test files ending in `_spec.rb`

### DIFF
--- a/lib/minitest_rerun_failed/failed_tests_reporter.rb
+++ b/lib/minitest_rerun_failed/failed_tests_reporter.rb
@@ -72,10 +72,10 @@ module Minitest
 
         # Get failure location as best we can from haystack
         if @include_line_numbers
-          regex_keeping_line_numbers = /(.+_test\.rb:[0-9]+)/
+          regex_keeping_line_numbers = /(.+(_test|_spec)\.rb:[0-9]+)/
           failure_file_location = tmp_haystack.join[regex_keeping_line_numbers, 1]
         else
-          regex_removing_line_numbers = /(.+_test\.rb):[0-9]+/
+          regex_removing_line_numbers = /(.+(_test|_spec)\.rb):[0-9]+/
           failure_file_location = tmp_haystack.join[regex_removing_line_numbers, 1]
         end
 


### PR DESCRIPTION
Some people use the spec style of Minitest and use the `_spec` suffix. I couldn’t figure out why this gem wasn’t working and then I realized it was specifically checking for `_test`. Would you be cool with adding support for it?

I’m sorry I could not figure out how to write tests for this. The test setup was a little too meta for me 😅