### PR TITLE
Fix failed test reruns

### DIFF
--- a/bin/rerun_failed_tests
+++ b/bin/rerun_failed_tests
@@ -3,28 +3,56 @@
 # See also:
 #   https://guides.rubygems.org/make-your-own-gem/#adding-an-executable
 
+require "English"
+
 filename = ".minitest_failed_tests.txt"
 dirpath = ENV["MINITEST_FAILED_TESTS_REPORT_DIR"] || "./"
 filepath = File.join(dirpath, filename)
 
-failed_tests = []
+def rails_installed?
+  Gem.loaded_specs.key?("rails")
+end
 
-if !File.exist?(filename)
-  puts "No #{filename} found"
-elsif File.empty?(filename)
-  puts "No failed tests in #{filename}"
-else
-  failed_tests += File.readlines(filepath).map{ _1.strip }
-  rails_installed = Gem.loaded_specs.has_key?("rails")
-  if rails_installed
-    cmd = "bundle exec rails test #{failed_tests.join(" ")}"
+def ruby_test_files(failed_tests)
+  failed_tests.map { |test_file| test_file.sub(/:[0-9]+\z/, "") }.uniq
+end
+
+def commands_for(failed_tests)
+  if rails_installed?
+    [
+      ["bundle", "exec", "rails", "test", *failed_tests]
+    ]
   else
-    cmd = "bundle exec ruby #{failed_tests.join(" ")}"
+    ruby_test_files(failed_tests).map do |test_file|
+      ["bundle", "exec", "ruby", test_file]
+    end
+  end
+end
+
+def run_command(command)
+  system(*command)
+  $CHILD_STATUS&.exitstatus || 1
+end
+
+def rerun_failed_tests(failed_tests)
+  commands_for(failed_tests).each do |command|
+    exit_status = run_command(command)
+    return exit_status unless exit_status.zero?
   end
 
-  IO.popen(cmd) do |io|
-    io.each do |line|
-      puts line
-    end
+  0
+end
+
+if !File.exist?(filepath)
+  puts "No #{filename} found"
+elsif File.empty?(filepath)
+  puts "No failed tests in #{filename}"
+else
+  failed_tests = File.readlines(filepath, chomp: true).map(&:strip).reject(&:empty?)
+
+  if failed_tests.empty?
+    puts "No failed tests in #{filename}"
+  else
+    exit rerun_failed_tests(failed_tests)
   end
 end

--- a/lib/minitest_rerun_failed/failed_tests_reporter.rb
+++ b/lib/minitest_rerun_failed/failed_tests_reporter.rb
@@ -27,13 +27,13 @@ module Minitest
         @file_output = options.fetch(:file_output, true)
         # What path to file?
         @output_path = options.fetch(:output_path, ".")
-        FileUtils.mkdir_p(@output_path) if @output_path
+        FileUtils.mkdir_p(@output_path) if @file_output && @output_path
 
         @output_file_path = File.join(@output_path, ".minitest_failed_tests.txt")
       end
 
       def record(test)
-        tests << test
+        super
       end
 
       def report
@@ -57,7 +57,7 @@ module Minitest
         end
 
         output_results(failure_paths, file_output)
-        File.write(@output_file_path, file_output.join("\n"), encoding: "UTF-8")
+        write_file_output(file_output) if @file_output
       end
 
       private
@@ -100,6 +100,11 @@ module Minitest
           file_output << stripped_path
           _puts color_red(stripped_path)
         end
+      end
+
+      def write_file_output(file_output)
+        output = file_output.empty? ? "" : "#{file_output.join("\n")}\n"
+        File.write(@output_file_path, output, encoding: "UTF-8")
       end
 
       def _puts(str)

--- a/test/meant_to_fail/another_example_test.rb
+++ b/test/meant_to_fail/another_example_test.rb
@@ -10,15 +10,15 @@ Minitest::Reporters.use!(
 )
 
 class AnotherExampleTest < Minitest::Test
-  def test1
+  def test_one
     assert false
   end
 
-  def test2
+  def test_two
     raise
   end
 
-  def test3
+  def test_three
     assert false
   end
 end

--- a/test/meant_to_fail/example_test.rb
+++ b/test/meant_to_fail/example_test.rb
@@ -10,39 +10,39 @@ Minitest::Reporters.use!(
 )
 
 class ExampleTest < Minitest::Test
-  def test1
+  def test_one
     assert false
   end
 
-  def test2
+  def test_two
     raise
   end
 
-  def test3
+  def test_three
     assert false
   end
 
-  def test4
+  def test_four
     assert false
   end
 
-  def test5
+  def test_five
     assert false
   end
 
-  def test6
+  def test_six
     assert false
   end
 
-  def test7
+  def test_seven
     assert false
   end
 
-  def test8
+  def test_eight
     assert false
   end
 
-  def test9
+  def test_nine
     assert false
   end
 end

--- a/test/real/minitest_rerun_failed_test.rb
+++ b/test/real/minitest_rerun_failed_test.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "fileutils"
+require "open3"
+require "rbconfig"
+require "tmpdir"
 
 # Which number test to run and fail
 FAIL_TEST_NAME = ENV["FAIL_TEST_NAME"]
@@ -28,6 +32,11 @@ else
 end
 
 class MinitestRerunFailedTest < Minitest::Test
+  ROOT = File.expand_path("../..", __dir__)
+  LIB_DIR = File.join(ROOT, "lib")
+  GEMFILE = File.join(ROOT, "Gemfile")
+  CLI_PATH = File.join(ROOT, "bin/rerun_failed_tests")
+
   # Suppress stdout / stderr output from secondary tests.
   # This is because we expect them to print a long stacktrace.
   # With it shown it would always look like tests failed.
@@ -67,6 +76,20 @@ class MinitestRerunFailedTest < Minitest::Test
     File.read("./test_output/#{name}/.minitest_failed_tests.txt")
   end
 
+  def subprocess_env(extra_env = {})
+    {
+      "BUNDLE_GEMFILE" => GEMFILE,
+      "RUBYLIB" => [LIB_DIR, ENV["RUBYLIB"]].compact.join(File::PATH_SEPARATOR)
+    }.merge(extra_env)
+  end
+
+  def capture_ruby(*args, chdir: nil, env: {})
+    options = {}
+    options[:chdir] = chdir if chdir
+
+    Open3.capture3(subprocess_env(env), RbConfig.ruby, *args, **options)
+  end
+
   # Stub test to ensure tests can run.
   # This is here b/c #suppress_output also hides eg Bundler::GemNotFound errors.
   # This test will print and show such issues.
@@ -83,7 +106,7 @@ class MinitestRerunFailedTest < Minitest::Test
   end
 
   def test_it_writes_failed_tests_to_file
-    refute fail_self_file_output.nil?
+    assert_match(%r{\Atest/real/minitest_rerun_failed_test.rb:[0-9]+\n\z}, fail_self_file_output)
   end
 
   def test_it_prints_failed_tests_with_seed
@@ -94,5 +117,101 @@ class MinitestRerunFailedTest < Minitest::Test
   def test_relevant_output_on_unexpected_errors
     assert_match(/Failed tests: [0-9]+ \(seed [0-9]+\)/, fail_self_console_output)
     assert_match(%r{test/real/minitest_rerun_failed_test.rb:[0-9]+\n}, fail_self_console_output)
+  end
+
+  def test_failed_tests_reporter_preserves_failed_exit_status
+    Dir.mktmpdir do |dir|
+      test_file = File.join(dir, "only_failed_reporter_test.rb")
+      File.write(test_file, <<~RUBY)
+        require "minitest/autorun"
+        require "minitest_rerun_failed"
+
+        Minitest::Reporters.use! [
+          Minitest::Reporters::FailedTestsReporter.new(verbose: false, file_output: false)
+        ]
+
+        class OnlyFailedReporterTest < Minitest::Test
+          def test_fail
+            assert false
+          end
+        end
+      RUBY
+
+      _stdout, _stderr, status = capture_ruby(test_file)
+
+      refute status.success?
+    end
+  end
+
+  def test_failed_tests_reporter_honors_file_output_false
+    Dir.mktmpdir do |dir|
+      output_path = File.join(dir, "report")
+      test_file = File.join(dir, "file_output_false_test.rb")
+      File.write(test_file, <<~RUBY)
+        require "minitest/autorun"
+        require "minitest_rerun_failed"
+
+        Minitest::Reporters.use! [
+          Minitest::Reporters::FailedTestsReporter.new(
+            output_path: #{output_path.dump},
+            verbose: false,
+            file_output: false
+          )
+        ]
+
+        class FileOutputFalseTest < Minitest::Test
+          def test_fail
+            assert false
+          end
+        end
+      RUBY
+
+      capture_ruby(test_file)
+
+      refute File.exist?(File.join(output_path, ".minitest_failed_tests.txt"))
+    end
+  end
+
+  def test_rerun_failed_tests_uses_custom_report_dir_and_runs_non_rails_files
+    Dir.mktmpdir do |dir|
+      report_dir = File.join(dir, "report")
+      test_dir = File.join(dir, "space path")
+      FileUtils.mkdir_p([report_dir, test_dir])
+
+      first_test = File.join(test_dir, "first_test.rb")
+      second_test = File.join(test_dir, "second_test.rb")
+      File.write(first_test, "puts \"FIRST_TEST_RAN\"\n")
+      File.write(second_test, "puts \"SECOND_TEST_RAN\"\n")
+      File.write(
+        File.join(report_dir, ".minitest_failed_tests.txt"),
+        "#{first_test}:123\n#{second_test}:456\n"
+      )
+
+      stdout, stderr, status = capture_ruby(
+        CLI_PATH,
+        chdir: dir,
+        env: { "MINITEST_FAILED_TESTS_REPORT_DIR" => "report" }
+      )
+
+      assert status.success?, stderr
+      assert_includes stdout, "FIRST_TEST_RAN"
+      assert_includes stdout, "SECOND_TEST_RAN"
+    end
+  end
+
+  def test_rerun_failed_tests_exits_with_child_status
+    Dir.mktmpdir do |dir|
+      report_dir = File.join(dir, "report")
+      FileUtils.mkdir_p(report_dir)
+      File.write(File.join(report_dir, ".minitest_failed_tests.txt"), "#{File.join(dir, "missing_test.rb")}\n")
+
+      _stdout, _stderr, status = capture_ruby(
+        CLI_PATH,
+        chdir: dir,
+        env: { "MINITEST_FAILED_TESTS_REPORT_DIR" => "report" }
+      )
+
+      refute status.success?
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Preserve Minitest reporter bookkeeping and honor file_output: false
- Make rerun_failed_tests use the configured report path, safe argv execution, plain Ruby reruns, and child exit status
- Make meant-to-fail fixtures discoverable and add regression coverage

## Validation
- mise exec ruby@3.3.5 -- bundle exec rake test
- mise exec ruby@3.3.5 -- bundle exec rake tests_meant_to_fail (expected failure; now runs 12 tests)
- git diff --check

Note: RuboCop could not run because the locked parser gem fails to load racc/parser under Ruby 3.3.5.