### PR TITLE
Prepare release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.3.0] - 2026-06-08
+- Fixed: Preserve Minitest failure status when `FailedTestsReporter` is used alone.
+- Fixed: Honor `file_output: false`.
+- Fixed: Use the configured report directory when rerunning failed tests.
+- Fixed: Handle rerun paths safely, support non-Rails test commands, and exit with the child test process status.
+- Fixed: Use Minitest source locations for failure reports so Ruby test files beyond `_test.rb` and `_spec.rb` can be rerun.
+- Added: `MinitestRerunFailed::Runner` for testable rerun command handling.
+- Changed: Modernized CI and RuboCop tooling.
+- Changed: Ignore local `Gemfile.lock` and `mise.toml` files for gem development.
+
 ## [0.2.3] - 2024-05-26
 - Added: Rerun tests executable
 

--- a/lib/minitest_rerun_failed/version.rb
+++ b/lib/minitest_rerun_failed/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MinitestRerunFailed
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Prepares v0.3.0 with the version bump and changelog entry.

Validation:
- mise exec -- bundle exec rake test
- mise exec -- bundle exec rake tests_meant_to_fail (expected failure fixture: 12 tests, 10 failures, 2 errors)
- RUBOCOP_CACHE_ROOT=tmp/rubocop_cache mise exec -- bundle exec rubocop --no-server --no-parallel
- git diff --check
- mise exec -- bundle exec rake build